### PR TITLE
add dependency injection annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ rome_module.provider('romeDefaults', function romeDefaultsProvider() {
   }
 });
 
-rome_module.directive('rome', function romeDirective(romeDefaults, $interval) {
+rome_module.directive('rome', ['romeDefaults', '$interval', function romeDirective(romeDefaults, $interval) {
   "use strict";
 
   function stringToBool(str) {
@@ -157,6 +157,6 @@ rome_module.directive('rome', function romeDirective(romeDefaults, $interval) {
       }, true);
     }
   };
-});
+}]);
 
 module.exports = rome_module;


### PR DESCRIPTION
Hello, Devin! 

Thank you for great rome directive!

I use browserify to bundle js files and apply ng-annotate and uglify transforms in production build.

If I include rome directive and run build, the resulting bundle throws exception due to angular injector unable to process rome directive. The reason for that is browserify doesn't apply transformations to external files (located in node_modules), so rome directive is left without annotations.

I see several solutions for this issue:
- tell browserify to apply global transformation (it makes ng-annotate process all node_modules, so build process becomes extremly slow)
- add `"browserify": {"transorm": ["browserify-ngannotate"]}` section to rome directive package.json (browserify will discover this option and apply transformation even for dependency from node_modules)
- simply add missing di annotations to directive source code.

In this PR I offer the last solution since it will work in all environments (not only with browserify, like second one).
